### PR TITLE
Fix YAML syntax error

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -85,7 +85,8 @@ body:
     id: terms
     attributes:
       label: Checklist
-      description: Please confirm the following before submitting:
+      description: |
+        Please confirm the following before submitting:
       options:
         - label: I have searched existing issues to avoid creating duplicates.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -51,7 +51,8 @@ body:
     id: checklist
     attributes:
       label: Checklist
-      description: Before submitting, please confirm:
+      description: |
+        Before submitting, please confirm:
       options:
         - label: I have searched existing issues to make sure this feature hasn’t been requested yet.
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -45,7 +45,8 @@ body:
     id: checklist
     attributes:
       label: Checklist
-      description: Before submitting, please confirm the following:
+      description: |
+        Before submitting, please confirm the following:
       options:
         - label: I have searched existing issues and discussions for a solution.
           required: true


### PR DESCRIPTION
Fix GitHub YAML syntax error for Issue Templates

<img width="811" height="99" alt="Screenshot 2025-09-14 at 12 35 56" src="https://github.com/user-attachments/assets/34a28272-bc06-430b-8eb3-2d12d63b1809" />
