### PR TITLE
fix(auth): stop persisting PocketBase JWT in localStorage (CWE-922)

### DIFF
--- a/application/src/lib/pocketbase.ts
+++ b/application/src/lib/pocketbase.ts
@@ -1,4 +1,4 @@
-import PocketBase from 'pocketbase';
+import PocketBase, { BaseAuthStore } from 'pocketbase';
 
 // Dynamically detect API base URL from current host (for use in browser)
 const dynamicBaseUrl =
@@ -28,8 +28,9 @@ export const setApiEndpoint = (endpoint: string): void => {
   }
 };
 
-// Initialize the PocketBase client with the current API URL
-export const pb = new PocketBase(getCurrentEndpoint());
+// Initialize the PocketBase client with an in-memory auth store so auth tokens
+// are not persisted in localStorage where XSS can trivially exfiltrate them.
+export const pb = new PocketBase(getCurrentEndpoint(), new BaseAuthStore());
 
 // Helper to check if user is authenticated
 export const isAuthenticated = () => {
@@ -39,28 +40,7 @@ export const isAuthenticated = () => {
 // Export the auth store for use in components
 export const authStore = pb.authStore;
 
-// Configure PocketBase to persist authentication between page reloads
+// Remove any auth tokens that may have been persisted by earlier versions.
 if (typeof window !== 'undefined') {
-  const storedAuthData = localStorage.getItem('pocketbase_auth');
-  if (storedAuthData) {
-    try {
-      const parsedData = JSON.parse(storedAuthData);
-      pb.authStore.save(parsedData.token, parsedData.model);
-    } catch (error) {
-      console.error('Failed to parse stored auth data:', error);
-      localStorage.removeItem('pocketbase_auth');
-    }
-  }
-
-  // Subscribe to authStore changes to persist authentication
-  pb.authStore.onChange(() => {
-    if (pb.authStore.isValid) {
-      localStorage.setItem('pocketbase_auth', JSON.stringify({
-        token: pb.authStore.token,
-        model: pb.authStore.model
-      }));
-    } else {
-      localStorage.removeItem('pocketbase_auth');
-    }
-  });
+  localStorage.removeItem('pocketbase_auth');
 }


### PR DESCRIPTION
## Summary

The PocketBase client in the SPA persists the authentication JWT in `localStorage` under the key `pocketbase_auth`. Because `localStorage` is accessible to any JavaScript executing on the same origin, an XSS vulnerability anywhere in the SPA — or temporary local browser access — would allow an attacker to exfiltrate a long-lived auth token and use it from a remote machine well beyond the lifetime of the original payload.

- **Weakness:** CWE-922 (Insecure Storage of Sensitive Information)
- **File:** `application/src/lib/pocketbase.ts`
- **Affected behavior:** an `onChange` handler wrote `{ token, model }` to `localStorage` on every auth change, and a startup block re-hydrated `pb.authStore` from it on each page load.

## Data flow

1. User authenticates → `pb.authStore` is updated.
2. `pb.authStore.onChange(...)` fires and calls `localStorage.setItem('pocketbase_auth', JSON.stringify({ token, model }))`.
3. Any script running in the origin can read `localStorage.getItem('pocketbase_auth')` and exfiltrate the token.
4. Token remains valid until expiry and can be replayed from anywhere — the attack outlives the XSS payload, the browser session, and even the user's awareness of compromise.

## Fix

Replace the default `LocalAuthStore` (which persists to `localStorage`) with an in-memory `BaseAuthStore`, and remove the explicit `onChange` persistence handler. A one-time cleanup line removes any token that previous versions may have already written, so existing users aren't left with a stale persisted token.

```ts
import PocketBase, { BaseAuthStore } from 'pocketbase';
// ...
export const pb = new PocketBase(getCurrentEndpoint(), new BaseAuthStore());
// ...
if (typeof window !== 'undefined') {
  localStorage.removeItem('pocketbase_auth');
}
```

The diff is intentionally minimal: 6 insertions, 26 deletions, scoped to a single file.

## Tradeoff

This is a UX-vs-security tradeoff: users will need to re-authenticate after a full page reload, since the token now lives only in memory. For an operational monitoring tool with privileged access to infrastructure data, persistent token theft is the larger risk. If session continuity across reloads is desired in the future, the recommended path is a server-set `HttpOnly; Secure; SameSite` cookie, which is not reachable from JavaScript and therefore not vulnerable to the same exfiltration class.

## Verification

- Searched the repository for other writers/readers of `pocketbase_auth` — the removed block was the only one. No other code path persists auth state.
- Confirmed `pb.authStore` continues to work for the in-memory case (PocketBase's `BaseAuthStore` exposes the same API used elsewhere in the app: `isValid`, `token`, `model`, `clear`, etc.).
- The cleanup `removeItem` is safe to run unconditionally and runs once per page load.
- No backend, schema, or API changes.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether existing mitigations would block exploitation: there is no Trusted Types policy, no strict CSP that would prevent inline script from reading `localStorage`, and no framework-level token isolation — React/Vite apps treat `localStorage` as fully script-readable by design. We also considered whether requiring an XSS precondition makes this redundant; it doesn't, because XSS by itself is ephemeral (script runs in the victim's tab, in the moment), whereas an exfiltrated JWT is portable and persistent — the attacker can authenticate from their own machine long after the XSS payload is gone. The fix removes that escalation path.

cc @lewiswigmore
